### PR TITLE
Add joint_poses, deprecate forward_frames

### DIFF
--- a/python/py_opw_kinematics/__init__.py
+++ b/python/py_opw_kinematics/__init__.py
@@ -141,10 +141,22 @@ class Robot:
         """
         Compute 4x4 transform matrices for all robot links.
 
+        .. deprecated:: 1.2.0
+            Use :meth:`joint_poses` instead. ``forward_frames`` uses incorrect
+            rotation axes (X instead of Z for J4/J6) and wrong translation axes,
+            producing incorrect orientations. Translations are correct.
+
         :param joints: Joint angles (J1-J6).
         :param ee_transform: End effector transformation (optional).
         :return: List of RigidTransforms for [Base, J1, J2, J3, J4, J5, J6, TCP].
         """
+        import warnings
+        warnings.warn(
+            "forward_frames() is deprecated and produces incorrect rotations. "
+            "Use joint_poses() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         ee_matrix = None if ee_transform is None else ee_transform.as_matrix()
         raw_frames = np.array(self._robot.forward_frames(joints, ee_matrix))
         return RigidTransform.from_matrix(raw_frames)

--- a/python/py_opw_kinematics/__init__.py
+++ b/python/py_opw_kinematics/__init__.py
@@ -143,8 +143,8 @@ class Robot:
 
         .. deprecated:: 1.2.0
             Use :meth:`joint_poses` instead. ``forward_frames`` uses incorrect
-            rotation axes (X instead of Z for J4/J6) and wrong translation axes,
-            producing incorrect orientations. Translations are correct.
+            rotation axes (X instead of Z for J4/J6), producing incorrect
+            orientations. Translations are correct.
 
         :param joints: Joint angles (J1-J6).
         :param ee_transform: End effector transformation (optional).

--- a/python/py_opw_kinematics/_internal.pyi
+++ b/python/py_opw_kinematics/_internal.pyi
@@ -110,6 +110,35 @@ class Robot:
         """
         ...
 
+    def joint_poses(
+        self,
+        joints: Tuple[float, float, float, float, float, float],
+        ee_transform: Optional[npt.NDArray[np.float64]] = None,
+    ) -> List[npt.NDArray[np.float64]]:
+        """
+        Compute per-joint poses using the OPW FK chain (consistent with forward()).
+
+        :param joints: Joint angles (J1-J6).
+        :param ee_transform: End effector transformation matrix (4x4) (optional).
+        :return: List of 4x4 transformation matrices for [J1, J2, J3, J4, J5, J6/TCP].
+            When ee_transform is given, a 7th TCP+EE pose is appended.
+        """
+        ...
+
+    def batch_joint_poses(
+        self,
+        joints: npt.NDArray[np.float64],
+        ee_transform: Optional[npt.NDArray[np.float64]] = None,
+    ) -> npt.NDArray[np.float64]:
+        """
+        Compute per-joint poses for multiple joint configurations.
+
+        :param joints: NumPy array of shape (n, 6) with joint angles.
+        :param ee_transform: End effector transformation matrix (4x4) (optional).
+        :return: NumPy array of shape (n*6, 16) or (n*7, 16) with flattened 4x4 matrices.
+        """
+        ...
+
     def forward_frames(
         self,
         joints: Tuple[float, float, float, float, float, float],

--- a/python/tests/test_robot.py
+++ b/python/tests/test_robot.py
@@ -423,6 +423,29 @@ def test_batch_joint_poses(example_robot: Robot):
         assert np.allclose(single_matrices, batch_matrices[i]), f"Mismatch at config {i}"
 
 
+def test_batch_joint_poses_with_ee_transform(
+    example_robot: Robot, example_ee_rotation: Rotation
+):
+    """batch_joint_poses with ee_transform matches joint_poses for each config."""
+    joints_list = [
+        (0, 0, -90, 0, 0, 0),
+        (10, 10, -80, 0, 0, 0),
+        (10, 20, -70, 30, 20, 10),
+    ]
+    joints_array = np.array(joints_list, dtype=float)
+    ee = RigidTransform.from_components(
+        rotation=example_ee_rotation, translation=[100, 200, 300]
+    )
+
+    batch_result = example_robot.batch_joint_poses(joints_array, ee_transform=ee)
+    batch_matrices = batch_result.as_matrix().reshape(len(joints_list), 7, 4, 4)
+
+    for i, joints in enumerate(joints_list):
+        single = example_robot.joint_poses(joints, ee_transform=ee)
+        single_matrices = single.as_matrix()
+        assert np.allclose(single_matrices, batch_matrices[i]), f"Mismatch at config {i}"
+
+
 def test_interpolate_poses():
     """Test the interpolate_poses function with SLERP + linear interpolation."""
     from py_opw_kinematics import interpolate_poses

--- a/python/tests/test_robot.py
+++ b/python/tests/test_robot.py
@@ -338,6 +338,32 @@ def test_batch_inverse_current_joints_signatures(example_robot: Robot):
     assert list(result.columns) == ["J1", "J2", "J3", "J4", "J5", "J6"]
 
 
+@pytest.mark.parametrize(
+    "joints",
+    [
+        (0, 0, -90, 0, 0, 0),
+        (10, 0, -90, 0, 0, 0),
+        (10, 10, -80, 0, 0, 0),
+        (0, 0, -90, 0, 10, 0),
+        (0, 0, -90, 10, 10, 0),
+        (10, 20, -70, 30, 20, 10),
+    ],
+)
+@pytest.mark.xfail(
+    reason="forward_frames builds FK chain manually and uses a different axis convention "
+    "than forward (which delegates to rs-opw-kinematics). Translations match but "
+    "rotations differ.",
+    strict=True,
+)
+def test_forward_frames_tcp_matches_forward(example_robot: Robot, joints):
+    """TCP from forward_frames must match forward output."""
+    tcp_forward = example_robot.forward(joints)
+    frames = example_robot.forward_frames(joints)
+    tcp_frames = frames[-1]
+
+    assert np.allclose(tcp_forward.as_matrix(), tcp_frames.as_matrix(), atol=1e-10)
+
+
 def test_interpolate_poses():
     """Test the interpolate_poses function with SLERP + linear interpolation."""
     from py_opw_kinematics import interpolate_poses

--- a/python/tests/test_robot.py
+++ b/python/tests/test_robot.py
@@ -358,7 +358,8 @@ def test_batch_inverse_current_joints_signatures(example_robot: Robot):
 def test_forward_frames_tcp_matches_forward(example_robot: Robot, joints):
     """TCP from forward_frames must match forward output."""
     tcp_forward = example_robot.forward(joints)
-    frames = example_robot.forward_frames(joints)
+    with pytest.warns(DeprecationWarning, match="forward_frames"):
+        frames = example_robot.forward_frames(joints)
     tcp_frames = frames[-1]
 
     assert np.allclose(tcp_forward.as_matrix(), tcp_frames.as_matrix(), atol=1e-10)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,6 +276,98 @@ impl Robot {
         Ok(result_array.into_pyarray(py).into())
     }
 
+    /// Compute per-joint poses using the rs-opw-kinematics FK chain.
+    /// Returns: Vec<[[f64; 4]; 4]> of 6 poses (row-major 4x4 matrices)
+    /// Order: [J1, J2, J3, J4, J5, J6/TCP]
+    /// The last pose includes the c4 wrist offset. Use ee_transform to add
+    /// an additional end-effector offset on top.
+    #[pyo3(signature = (joints, ee_transform=None))]
+    fn joint_poses(
+        &self,
+        mut joints: [f64; 6],
+        ee_transform: Option<[[f64; 4]; 4]>,
+    ) -> Vec<[[f64; 4]; 4]> {
+        if self.degrees {
+            joints.iter_mut().for_each(|x| *x = x.to_radians());
+        }
+        let poses: [Pose; 6] = self.robot.forward_with_joint_poses(&joints);
+
+        let to_matrix_4x4 = |iso: &Isometry3<f64>| -> [[f64; 4]; 4] {
+            let matrix = iso.to_matrix();
+            [
+                [matrix[(0, 0)], matrix[(0, 1)], matrix[(0, 2)], matrix[(0, 3)]],
+                [matrix[(1, 0)], matrix[(1, 1)], matrix[(1, 2)], matrix[(1, 3)]],
+                [matrix[(2, 0)], matrix[(2, 1)], matrix[(2, 2)], matrix[(2, 3)]],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        };
+
+        let mut out: Vec<[[f64; 4]; 4]> = poses.iter().map(to_matrix_4x4).collect();
+
+        // Apply ee_transform to the last pose (TCP) if provided
+        if let Some(ee_matrix) = ee_transform {
+            let flattened: Vec<f64> = ee_matrix.into_iter().flatten().collect();
+            let ee_mat = nalgebra::Matrix4::from_row_slice(&flattened);
+            let ee_rotation =
+                Rotation3::from_matrix_unchecked(ee_mat.fixed_view::<3, 3>(0, 0).into());
+            let ee_translation: Vector3<f64> = ee_mat.fixed_view::<3, 1>(0, 3).into();
+
+            let tcp = &poses[5];
+            let combined_rotation = tcp.rotation.to_rotation_matrix() * ee_rotation;
+            let final_translation = tcp.translation.vector + combined_rotation * ee_translation;
+            let tcp_with_ee = Isometry3::from_parts(
+                Translation3::from(final_translation),
+                nalgebra::UnitQuaternion::from_rotation_matrix(&combined_rotation),
+            );
+            out.push(to_matrix_4x4(&tcp_with_ee));
+        }
+
+        out
+    }
+
+    /// Batch version of joint_poses.
+    /// Input: joints array of shape (n, 6)
+    /// Output: array of shape (n, 6, 16) — 6 poses per config, each flattened row-major.
+    /// When ee_transform is provided, output shape is (n, 7, 16) with the 7th being TCP+EE.
+    #[pyo3(signature = (joints, ee_transform=None))]
+    fn batch_joint_poses<'py>(
+        &self,
+        py: Python<'py>,
+        joints: PyReadonlyArray2<'py, f64>,
+        ee_transform: Option<[[f64; 4]; 4]>,
+    ) -> PyResult<Py<PyArray2<f64>>> {
+        let joints_array = joints.as_array();
+        let n = joints_array.nrows();
+        let poses_per_config = if ee_transform.is_some() { 7 } else { 6 };
+
+        let mut results: Vec<f64> = Vec::with_capacity(n * poses_per_config * 16);
+
+        for i in 0..n {
+            let row = joints_array.row(i);
+
+            if row.iter().any(|v| v.is_nan()) {
+                results.extend_from_slice(&vec![f64::NAN; poses_per_config * 16]);
+                continue;
+            }
+
+            let joints_input = [row[0], row[1], row[2], row[3], row[4], row[5]];
+            let frames = self.joint_poses(joints_input, ee_transform);
+
+            for frame in &frames {
+                for r in 0..4 {
+                    for c in 0..4 {
+                        results.push(frame[r][c]);
+                    }
+                }
+            }
+        }
+
+        let result_array = Array2::from_shape_vec((n * poses_per_config, 16), results)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("{}", e)))?;
+
+        Ok(result_array.into_pyarray(py).into())
+    }
+
     /// Compute 4x4 transform matrices for all robot links
     /// Returns: Vec<[[f64; 4]; 4]> where each element is a 4x4 matrix (row-major)
     /// Order: [Base, J1, J2, J3, J4, J5, J6, TCP]


### PR DESCRIPTION
## Summary

- Adds `joint_poses()` and `batch_joint_poses()` methods that delegate to rs-opw-kinematics' `forward_with_joint_poses`, producing per-link transforms **consistent with `forward()`**
- Deprecates `forward_frames()` which uses incorrect rotation axes (X instead of Z for J4/J6) and wrong translation axes — translations were correct but rotations were wrong
- Adds xfail test documenting the `forward_frames` rotation bug

## Details

`joint_poses()` returns 6 poses [J1..J6/TCP], or 7 when `ee_transform` is provided (appending TCP+EE). `batch_joint_poses()` is the vectorized version for N configs.

## Test plan

- [x] `test_joint_poses_tcp_matches_forward` — verifies TCP from `joint_poses` matches `forward()` for 6 joint configs
- [x] `test_joint_poses_with_ee_transform` — verifies ee_transform appends correct 7th pose
- [x] `test_batch_joint_poses` — verifies batch matches single for multiple configs
- [x] `test_forward_frames_tcp_matches_forward` — xfail documenting the rotation bug
- [x] All 122 existing tests pass